### PR TITLE
French resdoc TABLES section to appear as TABLEAUX, and Table caption…

### DIFF
--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -55,7 +55,7 @@
 %%  - Run the following command to rebuild the font map files:
 %%     initexmf --mkmaps
 %% ------------------------------------------------------------------------------
-
+%%\usepackage[french]{babel}
 %% ------------------------------------------------------------------------------
 %% Use the resDoc.bst file for bibliography style.
 \usepackage{natbib}
@@ -229,7 +229,7 @@
   \pagenumbering{roman}
   %% TOC is required by CSAS to be on page iii.
   \setcounter{page}{3}
-  \renewcommand{\contentsname}{\bf \large \vspace{-20mm} TABLE OF CONTENTS}
+  \renewcommand{\contentsname}{\bf \large \vspace{-20mm} SOMMAIRE}
   \addtocontents{toc}{\protect\thispagestyle{fancy}}
   \begin{center}
     \tableofcontents

--- a/inst/csas-tex/res-doc-french.tex
+++ b/inst/csas-tex/res-doc-french.tex
@@ -1,5 +1,5 @@
 % Documents setup
-\documentclass[11pt]{book}
+\documentclass[french,11pt]{book}
 
 % fix for pandoc 1.14
 \providecommand{\tightlist}{%
@@ -93,7 +93,7 @@
 \newcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{{#1}}}}
 
 \begin{document}
-
+\renewcommand{\tablename}{Tableau}
 \frontmatter
 
 $body$


### PR DESCRIPTION
… also to appear as Tableau. I thought that modifying the documentclass to have french as an option would be sufficient (see line 2 of inst/csas-tex/res-doc-french.tex on this commit), but I also had to renewcommand for tablename to Tableau, see line 96 of inst/csas-tex/res-doc-french.tex on this commit for the rendered PDF to show both the TABLES section to TABLEAUX and for Table captions to show as Tableau.