### PR TITLE
Update cover page font to Large-large

### DIFF
--- a/inst/csas-style/tech-report.sty
+++ b/inst/csas-style/tech-report.sty
@@ -263,17 +263,17 @@
 \DisableFootNotes
 \noindent
 \begin{flushleft}
-\LARGE
+\Large
 \textbf{\trTitle{}}\\
 \vfill
-\Large
+\large
 \trAuthsLong{}
 \vfill
 \trAddy{}
 \vfill
 \trYear{}
 \vfill
-\LARGE
+\Large
 \textbf{Canadian Technical Report of\\
 Fisheries and Aquatic Sciences \trReportNum{}}
 \lfoot{\includegraphics[height=7mm, keepaspectratio]{\locRepo/images/LogoDFO.png}}


### PR DESCRIPTION
Suggest edit to cover page font to Large-large from LARGE-Large. This is closer to the 18pt-14pt font size combination in the cover page word template provided for technical reports.