### PR TITLE
adding French functionality to Tech Report

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -81,18 +81,30 @@ resdoc_word <- function(french = FALSE, ...) {
 
 #' @export
 #' @rdname csas_pdf
-sr_pdf <- function(latex_engine = "pdflatex", ...) {
+sr_pdf <- function(latex_engine = "pdflatex", french = FALSE, ...) {
+
+  if (french) {
+    file <- system.file("csas-tex", "sr-french.tex", package = "csasdown")
+  } else {
+    file <- system.file("csas-tex", "sr.tex", package = "csasdown")
+  }
+
   base <- bookdown::pdf_book(
-    template = system.file("csas-tex", "sr.tex", package = "csasdown"),
+    template = file,
     keep_tex = TRUE,
     pandoc_args = c("--top-level-division=chapter", "--wrap=none"),
     latex_engine = latex_engine,
     ...
   )
   update_csasstyle()
+  
   base$knitr$opts_chunk$comment <- NA
   old_opt <- getOption("bookdown.post.latex")
-  options(bookdown.post.latex = fix_envs)
+  
+  if (french)
+    options(bookdown.post.latex = fix_envs_resdoc_french)
+  else
+    options(bookdown.post.latex = fix_envs)
   on.exit(options(bookdown.post.late = old_opt))
   base
 }
@@ -374,3 +386,4 @@ check_yaml <- function(type = "resdoc") {
     message("Your `index.Rmd` file contains all necessary YAML options.")
   }
 }
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,9 +141,13 @@ techreport_pdf <- function(french = FALSE, latex_engine = "pdflatex", ...) {
   )
 
   update_csasstyle()
+  
   base$knitr$opts_chunk$comment <- NA
   old_opt <- getOption("bookdown.post.latex")
-  options(bookdown.post.latex = fix_envs_tr)
+  if (french)
+	options(bookdown.post.latex = fix_envs_tr_french)
+  else
+	options(bookdown.post.latex = fix_envs_tr)
   on.exit(options(bookdown.post.late = old_opt))
   base
 }
@@ -156,6 +160,10 @@ update_csasstyle <- function() {
 
 fix_envs_tr <- function(x) {
   fix_envs(x, join_abstract = FALSE)
+}
+
+fix_envs_tr_french <- function(x) {
+  fix_envs(x, join_abstract = FALSE, french = TRUE)
 }
 
 fix_envs_resdoc_french <- function(x) {

--- a/inst/csas-style/sr-french.sty
+++ b/inst/csas-style/sr-french.sty
@@ -673,7 +673,7 @@ Centre des avis scientifiques\\
 \rdAddress{}\\
 \vspace{0.1cm}
 T\'{e}l\'{e}phone: \rdPhone{}\\
-Courriel: \href{mailto:\rdEmail}{\rdEmail}\\
+Courriel: \rdEmail\\
 Addresse internet: \href{http://www.dfo-mpo.gc.ca/csas-sccs/}{www.dfo-mpo.gc.ca/csas-sccs/}\\
 \vspace{0.1cm}
 ISSN 1919-3769\\
@@ -692,10 +692,9 @@ Secr.\ can.\ de consult.\ sci.\ du MPO, R\'{e}p.\ des Sci.\
 \emph{Also available in English:}
 
 \hangindent=0.6cm
-\emph{DFO. \rdYear{}. \rdTitleEn{}.
+DFO. \rdYear{}. \rdTitleFr{}.
 DFO Can.\ Sci.\ Advis.\ Sec.\ Sci.\ Resp.
-\rdYear{}/\rdNumber{}.}
-
+\rdYear{}/\rdNumber{}.
 
 \newpage
 }

--- a/inst/csas-style/tech-report-french.sty
+++ b/inst/csas-style/tech-report-french.sty
@@ -377,23 +377,40 @@ On doit citer la publication comme suit:
 % Add TOC to pdf bookmarks (clickable pdf)
 \pdfbookmark[1]{\contentsname}{toc}
 
+\newcommand\TableOfContents{
+  \thispagestyle{fancyplain}
+  \pagenumbering{roman}
+  %% TOC is required by CSAS to be on page iii.
+  \setcounter{page}{3}
+  \renewcommand{\contentsname}{\bf \large \vspace{-20mm} TABLE DES MATI\`ERES}
+  \addtocontents{toc}{\protect\thispagestyle{fancy}}
+  \begin{center}
+    \tableofcontents
+  \end{center}
+  \newpage
+  %% To number subsubheadings
+  \setcounter{secnumdepth}{5}
+}
+
 % Table of contents page
-\tableofcontents\clearpage
+% \tableofcontents\clearpage
+\TableOfContents
+
 
 % Lists of figures and tables (optional)
 % \listoffigures \listoftables \clearpage
 
 % Abstract page(s)
-\section*{ABSTRACT}\addcontentsline{toc}{section}{ABSTRACT}
-\trCitation{}
-\bigskip
-\trAbstract{}
-\clearpage
 \section*{R\'{E}SUM\'{E}}\addcontentsline{toc}{section}{R\'{E}SUM\'{E}}
 \trCitation{}
 \bigskip
 \trResume{}
 \label{TRlastRoman}
+\clearpage
+\section*{ABSTRACT}\addcontentsline{toc}{section}{ABSTRACT}
+\trCitation{}
+\bigskip
+\trAbstract{}
 \clearpage
 
 % Settings for the main document

--- a/inst/csas-tex/sr-french.tex
+++ b/inst/csas-tex/sr-french.tex
@@ -1,0 +1,68 @@
+% Document setup
+\documentclass[11pt]{book}
+
+% Location of the csas-style repository: adjust path as needed
+\newcommand{\locRepo}{csas-style}
+
+% Use the style file in the csas-style repository (sr.sty)
+\usepackage{\locRepo/sr-french}
+
+% header-includes from R markdown entry
+$header-includes$
+
+% Bibliography style file
+% \bibliographystyle{../csas-style/res-doc}
+
+%%%% Commands for title page etc %%%%%
+
+% Title
+\newcommand{\rdTitle}{$title$}
+
+% French title
+\newcommand{\rdTitleFr}{$title_other$}
+
+% Title short
+\newcommand{\rdTitleShort}{$title_short$}
+
+% Publication year
+\newcommand{\rdYear}{$year$}
+
+% Publication month
+\newcommand{\rdMonth}{$month$}
+
+% Report number
+\newcommand{\rdNumber}{$report_number$}
+
+% Approver (name\\position)
+\newcommand{\rdApp}{$approver$}
+% \newcommand{\rdYear}{$approval_year$}
+% \newcommand{\rdAppMonth}{$approval_month$}
+% \newcommand{\rdAppDay}{$approval_day$}
+\newcommand{\rdAppDate}{$approval_month$ $approval_day$, $approval_year$}
+
+% Branch
+\newcommand{\rdBranch}{$branch$}
+
+% Region
+\newcommand{\rdRegion}{$region$}
+
+% Address
+\newcommand{\rdAddress}{$address$}
+
+% Phone
+\newcommand{\rdPhone}{$phone$}
+
+% Email
+\newcommand{\rdEmail}{$email$}
+
+%%%% End of title page commands %%%%%
+
+\begin{document}
+
+\MakeFirstPage
+
+$body$
+
+\MakeAvailable
+
+\end{document}

--- a/inst/csas-tex/tech-report-french.tex
+++ b/inst/csas-tex/tech-report-french.tex
@@ -77,10 +77,10 @@ $header-includes$
 % New definition: Address
 \newcommand{\trAddy}{$address$}
 
-% Abstract
+% Resume
 \newcommand{\trAbstract}{$abstract$}
 
-% Resume (i.e., French abstract)
+% Abstract (i.e., English abstract)
 \newcommand{\trResume}{$abstract_other$}
 
 %%%%% Start %%%%%
@@ -88,6 +88,7 @@ $header-includes$
 % Start the document
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 \begin{document}
+\renewcommand{\tablename}{Tableau}
 
 %%%% Front matter %%%%%
 

--- a/inst/rmarkdown/templates/resdoc/skeleton/04-references.Rmd
+++ b/inst/rmarkdown/templates/resdoc/skeleton/04-references.Rmd
@@ -1,5 +1,5 @@
 <!-- In general, you shouldn't need to edit this file with the exception of
-the following French/English translation. For a French document, set the following header to: # RÉFÉRENCES {-} -->
+the following French/English translation. For a French document, set the following header to: # RÉFÉRENCES CITÉES {-} -->
 
 \clearpage
 

--- a/inst/rmarkdown/templates/sr/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/sr/skeleton/skeleton.Rmd
@@ -24,9 +24,9 @@ address: |
 phone: (250) 756-7208
 email: csap@dfo-mpo.gc.ca
 output:
- csasdown::sr_pdf
+ csasdown::sr_pdf:
   # csasdown::sr_word:
-    # french: false
+   french: false
 type:
   sr
 # ------------

--- a/inst/rmarkdown/templates/techreport/skeleton/06_bibliography.Rmd
+++ b/inst/rmarkdown/templates/techreport/skeleton/06_bibliography.Rmd
@@ -2,6 +2,9 @@
 <!-- <div id="refs"></div> -->
 <!-- where you want it to appear -->
 
+<!-- In general, you shouldn't need to edit this file with the exception of
+the following French/English translation. For a French document, set the following header to: # Références Citées  {-} -->
+
 \clearpage
 
 # References


### PR DESCRIPTION
@seananderson , I noticed that these edits create a weird pagination in the Table of Contents of the Tech Report. I used the same approach as in the Res Doc, so not sure why the Table des Matières on page iii has this look:
![Capture](https://user-images.githubusercontent.com/1110182/64259731-0148ab00-cf00-11e9-9943-3ebe8bc7dcc0.PNG)
