### PR TITLE
The roman page number used in the French tech report citation was wrong.

### DIFF
--- a/inst/csas-style/tech-report-french.sty
+++ b/inst/csas-style/tech-report-french.sty
@@ -397,12 +397,12 @@ On doit citer la publication comme suit:
 \trCitation{}
 \bigskip
 \trResume{}
-\label{TRlastRoman}
 \clearpage
 \section*{ABSTRACT}\addcontentsline{toc}{section}{ABSTRACT}
 \trCitation{}
 \bigskip
 \trAbstract{}
+\label{TRlastRoman}
 \clearpage
 
 % Settings for the main document


### PR DESCRIPTION
I just moved `\label{TRlastRoman}` so that it is located on the abstract page and not the page before.