### PR TITLE
fix to stop res-doc.sty being modified despite copy_sty set to false

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -229,7 +229,6 @@ update_csasstyle <- function(copy = TRUE, line_nums = TRUE, line_nums_mod = 1, w
   if (copy || (!dir.exists("csas-style") && !copy)) {
     dir.create("csas-style", showWarnings = FALSE)
     ignore <- file.copy(fn, ".", overwrite = TRUE, recursive = TRUE)
-  }
   if(line_nums){
     csas_style <- readLines(here::here("csas-style", which_sty))
     if(length(grep("res-doc", which_sty))){
@@ -244,6 +243,7 @@ update_csasstyle <- function(copy = TRUE, line_nums = TRUE, line_nums_mod = 1, w
       csas_style <- c(csas_style, "\\linenumbers", modulo)
       writeLines(csas_style, here::here("csas-style", which_sty))
     }
+  }
   }
 }
 


### PR DESCRIPTION
stop the addition of 2 lines associated with line numbering to the style file on each knit, occured even when copy_sty was false

after a few knits, my .sty file looked like this:

```
%% Frontmatter: set up first few pages including the title page, TOC, and abstract
%% Note that this requires some custom variables that you need to set in the main
%% document (e.g., title, authors, year, report number)
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\modulolinenumbers[1]
\linenumbers
\def\frontmatter{%

\thispagestyle{empty}
```
