### PR TITLE
Remove widow lines

### DIFF
--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -2,6 +2,7 @@
 %%  Science Advisory Secretariat Research Documents.
 
 \usepackage{tabularx}
+\usepackage[all]{nowidow} 
 
 %% Use the resDoc.bst file for bibliography style.
 \usepackage{natbib}

--- a/inst/csas-style/res-doc.sty
+++ b/inst/csas-style/res-doc.sty
@@ -2,6 +2,7 @@
 %%  Science Advisory Secretariat Research Documents.
 
 \usepackage{tabularx}
+\usepackage[all]{nowidow} 
 
 %% ------------------------------------------------------------------------------
 %% Use the resDoc.bst file for bibliography style.


### PR DESCRIPTION
This change prevents single lines to be split off from a paragraph and moved to the next page. This is especially helpful in preventing references from being split over two pages, which was a problem we had to fix in our final resdoc before it would be accepted. This change has already been implemented in the sr.sty file.