### PR TITLE
Fixed header and footer on landscape pages

### DIFF
--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -57,6 +57,8 @@
             justification=raggedright,
             singlelinecheck=false]
            {caption}
+%%% To add headers and footers to landscape pages
+\usepackage{everypage}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
@@ -312,7 +314,7 @@
 %%  be along the long side for ease of reading in a PDF viewer.
 \newenvironment{landscapepage}[1]{
   \newgeometry{hmargin=1in,vmargin=1in}
-  \thispagestyle{csaplscape}
+  \pagestyle{empty}
   \begin{landscape}
     \centering
     #1
@@ -323,22 +325,32 @@
 }
 
 \makeatother
+%% Creates a header and footer on the long page sides on landscape pages
+\AddEverypageHook{\ifdim\textwidth=\textheight
+  \fancyhf{}\fancyfoot{}
+\begin{textblock}{0.05}(0.925,0.5)
+{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
+ \begin{textblock}{1}(0.1,0.0909)
+{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+  \begin{textblock}{1}(0.9,0.0909)
+  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\fi}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
 %% For landscape pages in CSAS documents
-% \usepackage{pdflscape}
-\usepackage{lscape}
+\usepackage{pdflscape}
+%\usepackage{lscape}
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
   {8.5in}
 \setlength{\TPVertModule}
   {11.0in}
-\fancypagestyle{csaplscape}{
+%\fancypagestyle{csaplscape}{
   %% The argument is the left footer text
   %% clear all header and footer fields
-  \fancyhf{}
-  \fancyfoot{}
+ % \fancyhf{}
+  %\fancyfoot{}
   %% Make the footers appear in landscape mode
   %% The 25pt in the first line adjusts the height (in landscape mode)
   %%  and the 90 rotates the footer name. The \footskip+0.0 makes it align
@@ -350,30 +362,30 @@
   %%  footer is and the 1.3 to fit it. This is a hack, no time to figure it out.
   %% \fancyfoot[R]{\makebox[\textwidth+25pt][r]{
   %%    \smash{\raisebox{\dimexpr\footskip+1.3\textheight}{\rotatebox{90}{DRAFT}}}}}
-  \begin{textblock}
-    {1}(0.1,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {1}(0.9,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {0.05}(0.925,0.5)
-    {\rotatebox{90}
-      {\thepage}
-    }
-  \end{textblock}
+ % \begin{textblock}
+ %   {1}(0.1,0.0909)
+  %  {\rotatebox{90}
+ %     {\rule{9in}{0.25pt}}
+  %  }
+%  \end{textblock}
+ % \begin{textblock}
+%    {1}(0.9,0.0909)
+%    {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+%    }
+%  \end{textblock}
+%  \begin{textblock}
+%    {0.05}(0.925,0.5)
+ %   {\rotatebox{90}
+ %     {\thepage}
+ %   }
+%  \end{textblock}
   %% Get rid of lines along sides of landscape page
-  \renewcommand{\headrulewidth}
-    {0pt}
-  \renewcommand{\footrulewidth}
-    {0pt}
-}
+%  \renewcommand{\headrulewidth}
+%    {0pt}
+%  \renewcommand{\footrulewidth}
+ %   {0pt}
+%}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------

--- a/inst/csas-style/res-doc.sty
+++ b/inst/csas-style/res-doc.sty
@@ -58,6 +58,8 @@
             justification=raggedright,
             singlelinecheck=false]
            {caption}
+%%% To add headers and footers to landscape pages
+\usepackage{everypage}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
@@ -313,7 +315,8 @@
 %%  be along the long side for ease of reading in a PDF viewer.
 \newenvironment{landscapepage}[1]{
   \newgeometry{hmargin=1in,vmargin=1in}
-  \thispagestyle{csaplscape}
+\pagestyle{empty} % to clear portrait header and footer from page
+ % \thispagestyle{csaplscape}
   \begin{landscape}
     \centering
     #1
@@ -324,22 +327,33 @@
 }
 
 \makeatother
+%% Creates a header and footer on the long page sides on landscape pages
+\AddEverypageHook{\ifdim\textwidth=\textheight
+  \fancyhf{}\fancyfoot{}
+\begin{textblock}{0.05}(0.925,0.5)
+{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
+ \begin{textblock}{1}(0.1,0.0909)
+{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+  \begin{textblock}{1}(0.9,0.0909)
+  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\fi}
+
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
 %% For landscape pages in CSAS documents
-% \usepackage{pdflscape}
-\usepackage{lscape}
+\usepackage{pdflscape} % rotates landscape pages
+%\usepackage{lscape}
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
   {8.5in}
 \setlength{\TPVertModule}
   {11.0in}
-\fancypagestyle{csaplscape}{
+%\fancypagestyle{csaplscape}{
   %% The argument is the left footer text
   %% clear all header and footer fields
-  \fancyhf{}
-  \fancyfoot{}
+%  \fancyhf{}
+%  \fancyfoot{}
   %% Make the footers appear in landscape mode
   %% The 25pt in the first line adjusts the height (in landscape mode)
   %%  and the 90 rotates the footer name. The \footskip+0.0 makes it align
@@ -351,30 +365,30 @@
   %%  footer is and the 1.3 to fit it. This is a hack, no time to figure it out.
   %% \fancyfoot[R]{\makebox[\textwidth+25pt][r]{
   %%    \smash{\raisebox{\dimexpr\footskip+1.3\textheight}{\rotatebox{90}{DRAFT}}}}}
-  \begin{textblock}
-    {1}(0.1,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {1}(0.9,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {0.05}(0.925,0.5)
-    {\rotatebox{90}
-      {\thepage}
-    }
-  \end{textblock}
+%  \begin{textblock}
+ %   {1}(0.1,0.0909)
+ %   {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+ %   }
+%  \end{textblock}
+%  \begin{textblock}
+%    {1}(0.9,0.0909)
+%    {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+%    }
+%  \end{textblock}
+%  \begin{textblock}
+%    {0.05}(0.925,0.5)
+%    {\rotatebox{90}
+%      {\thepage}
+%    }
+%  \end{textblock}
   %% Get rid of lines along sides of landscape page
-  \renewcommand{\headrulewidth}
-    {0pt}
-  \renewcommand{\footrulewidth}
-    {0pt}
-}
+%  \renewcommand{\headrulewidth}
+%    {0pt}
+%  \renewcommand{\footrulewidth}
+%    {0pt}
+%}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------


### PR DESCRIPTION
This change correctly rotates landscape pages and places the header and footer in the correct places on the landscape page (the way CSAS would like them). This also works for multipage tables. 

The actual implementation of the landscape page requires the use of the landscapepage environment (which you put around the r code chunk in rmarkdown) and setting landscape to FALSE in the csas_table function (or more specifically, not setting landscape = TRUE). Here is an example
```latex
\clearpage 
\begin{landscapepage}
```
````
```{r longtable}
csasdown::csas_table(widelong_df,
 col.names = c("Year", as.character(ages)),
 caption = "A long and wide table",
 format = "latex",
 landscape = FALSE, font_size = 8)
```
````
```latex
\end{landscapepage}
\clearpage
```
Maybe someone else has an elegant solution to making the implementation more intuitive and user-friendly (i.e. not having to specify landscape = FALSE for landscape pages).