### PR TITLE
Removed landscape from csas_table

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -9,7 +9,6 @@
 #' @param linesep As defined by [knitr::kable()].
 #' @param longtable As defined by [knitr::kable()].
 #' @param font_size Font size in pts. If NULL, document font size is used.
-#' @param landscape Make this table in landscape orientation?
 #' @param bold_header Make headers bold. Logical
 #' @param repeat_header If landscape, repeat the header on subsequent pages?
 #' @param repeat_header_text Use to write a Continued.. messgae continuing pages
@@ -47,7 +46,6 @@ csas_table <- function(x,
                        linesep = "",
                        longtable = TRUE,
                        font_size = NULL,
-                       landscape = FALSE,
                        bold_header = TRUE,
                        repeat_header = TRUE,
                        repeat_header_text = "",
@@ -101,9 +99,6 @@ csas_table <- function(x,
   }
   if (bold_header) {
     suppressWarnings(k <- row_spec(k, 0, bold = TRUE))
-  }
-  if (landscape) {
-    k <- landscape(k)
   }
   if (repeat_header) {
     suppressWarnings(

--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -57,6 +57,8 @@
             justification=raggedright,
             singlelinecheck=false]
            {caption}
+%%% To add headers and footers to landscape pages
+\usepackage{everypage}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
@@ -312,7 +314,7 @@
 %%  be along the long side for ease of reading in a PDF viewer.
 \newenvironment{landscapepage}[1]{
   \newgeometry{hmargin=1in,vmargin=1in}
-  \thispagestyle{csaplscape}
+  \pagestyle{empty}
   \begin{landscape}
     \centering
     #1
@@ -323,22 +325,32 @@
 }
 
 \makeatother
+%% Creates a header and footer on the long page sides on landscape pages
+\AddEverypageHook{\ifdim\textwidth=\textheight
+  \fancyhf{}\fancyfoot{}
+\begin{textblock}{0.05}(0.925,0.5)
+{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
+ \begin{textblock}{1}(0.1,0.0909)
+{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+  \begin{textblock}{1}(0.9,0.0909)
+  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\fi}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
 %% For landscape pages in CSAS documents
-% \usepackage{pdflscape}
-\usepackage{lscape}
+\usepackage{pdflscape}
+%\usepackage{lscape}
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
   {8.5in}
 \setlength{\TPVertModule}
   {11.0in}
-\fancypagestyle{csaplscape}{
+%\fancypagestyle{csaplscape}{
   %% The argument is the left footer text
   %% clear all header and footer fields
-  \fancyhf{}
-  \fancyfoot{}
+ % \fancyhf{}
+  %\fancyfoot{}
   %% Make the footers appear in landscape mode
   %% The 25pt in the first line adjusts the height (in landscape mode)
   %%  and the 90 rotates the footer name. The \footskip+0.0 makes it align
@@ -350,30 +362,30 @@
   %%  footer is and the 1.3 to fit it. This is a hack, no time to figure it out.
   %% \fancyfoot[R]{\makebox[\textwidth+25pt][r]{
   %%    \smash{\raisebox{\dimexpr\footskip+1.3\textheight}{\rotatebox{90}{DRAFT}}}}}
-  \begin{textblock}
-    {1}(0.1,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {1}(0.9,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {0.05}(0.925,0.5)
-    {\rotatebox{90}
-      {\thepage}
-    }
-  \end{textblock}
+ % \begin{textblock}
+ %   {1}(0.1,0.0909)
+  %  {\rotatebox{90}
+ %     {\rule{9in}{0.25pt}}
+  %  }
+%  \end{textblock}
+ % \begin{textblock}
+%    {1}(0.9,0.0909)
+%    {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+%    }
+%  \end{textblock}
+%  \begin{textblock}
+%    {0.05}(0.925,0.5)
+ %   {\rotatebox{90}
+ %     {\thepage}
+ %   }
+%  \end{textblock}
   %% Get rid of lines along sides of landscape page
-  \renewcommand{\headrulewidth}
-    {0pt}
-  \renewcommand{\footrulewidth}
-    {0pt}
-}
+%  \renewcommand{\headrulewidth}
+%    {0pt}
+%  \renewcommand{\footrulewidth}
+ %   {0pt}
+%}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------

--- a/inst/csas-style/res-doc.sty
+++ b/inst/csas-style/res-doc.sty
@@ -58,6 +58,8 @@
             justification=raggedright,
             singlelinecheck=false]
            {caption}
+%%% To add headers and footers to landscape pages
+\usepackage{everypage}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
@@ -313,7 +315,8 @@
 %%  be along the long side for ease of reading in a PDF viewer.
 \newenvironment{landscapepage}[1]{
   \newgeometry{hmargin=1in,vmargin=1in}
-  \thispagestyle{csaplscape}
+\pagestyle{empty} % to clear portrait header and footer from page
+ % \thispagestyle{csaplscape}
   \begin{landscape}
     \centering
     #1
@@ -324,22 +327,33 @@
 }
 
 \makeatother
+%% Creates a header and footer on the long page sides on landscape pages
+\AddEverypageHook{\ifdim\textwidth=\textheight
+  \fancyhf{}\fancyfoot{}
+\begin{textblock}{0.05}(0.925,0.5)
+{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
+ \begin{textblock}{1}(0.1,0.0909)
+{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+  \begin{textblock}{1}(0.9,0.0909)
+  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\fi}
+
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------
 %% For landscape pages in CSAS documents
-% \usepackage{pdflscape}
-\usepackage{lscape}
+\usepackage{pdflscape} % rotates landscape pages
+%\usepackage{lscape}
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
   {8.5in}
 \setlength{\TPVertModule}
   {11.0in}
-\fancypagestyle{csaplscape}{
+%\fancypagestyle{csaplscape}{
   %% The argument is the left footer text
   %% clear all header and footer fields
-  \fancyhf{}
-  \fancyfoot{}
+%  \fancyhf{}
+%  \fancyfoot{}
   %% Make the footers appear in landscape mode
   %% The 25pt in the first line adjusts the height (in landscape mode)
   %%  and the 90 rotates the footer name. The \footskip+0.0 makes it align
@@ -351,30 +365,30 @@
   %%  footer is and the 1.3 to fit it. This is a hack, no time to figure it out.
   %% \fancyfoot[R]{\makebox[\textwidth+25pt][r]{
   %%    \smash{\raisebox{\dimexpr\footskip+1.3\textheight}{\rotatebox{90}{DRAFT}}}}}
-  \begin{textblock}
-    {1}(0.1,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {1}(0.9,0.0909)
-    {\rotatebox{90}
-      {\rule{9in}{0.25pt}}
-    }
-  \end{textblock}
-  \begin{textblock}
-    {0.05}(0.925,0.5)
-    {\rotatebox{90}
-      {\thepage}
-    }
-  \end{textblock}
+%  \begin{textblock}
+ %   {1}(0.1,0.0909)
+ %   {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+ %   }
+%  \end{textblock}
+%  \begin{textblock}
+%    {1}(0.9,0.0909)
+%    {\rotatebox{90}
+%      {\rule{9in}{0.25pt}}
+%    }
+%  \end{textblock}
+%  \begin{textblock}
+%    {0.05}(0.925,0.5)
+%    {\rotatebox{90}
+%      {\thepage}
+%    }
+%  \end{textblock}
   %% Get rid of lines along sides of landscape page
-  \renewcommand{\headrulewidth}
-    {0pt}
-  \renewcommand{\footrulewidth}
-    {0pt}
-}
+%  \renewcommand{\headrulewidth}
+%    {0pt}
+%  \renewcommand{\footrulewidth}
+%    {0pt}
+%}
 %% ------------------------------------------------------------------------------
 
 %% ------------------------------------------------------------------------------


### PR DESCRIPTION
Removed landscape from csas_table in order to allow functionality of new rotated pages. The .Rd file will have to be updated. @cgrandin Also, both my other commits are still attached to this pull request and I cannot seem to remove them. Let me know if there's a better way to give you the csas_table changes.