### PR TITLE
Added hlines to h/f

### DIFF
--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -337,11 +337,11 @@
 %% Creates a header and footer on the long page sides on landscape pages
 \AddEverypageHook{\ifdim\textwidth=\textheight
   \fancyhf{}\fancyfoot{}
- \begin{textblock}{0.05}(0.925,0.5)
+ \begin{textblock}{0.05}(0.9,0.5)
  {\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
-  \begin{textblock}{1}(0.1,0.0909)
+  \begin{textblock}{0.05}(0.062,0.0909){\rotatebox{90}{\rule{9in}{0.25pt}}}
   \end{textblock}
-  \begin{textblock}{1}(0.9,0.0909)
+  \begin{textblock}{0.05}(0.875,0.0909){\rotatebox{90}{\rule{9in}{0.25pt}}}
   \end{textblock}
 \fi}
 

--- a/inst/csas-style/res-doc.sty
+++ b/inst/csas-style/res-doc.sty
@@ -337,11 +337,11 @@
 %% Creates a header and footer on the long page sides on landscape pages
 \AddEverypageHook{\ifdim\textwidth=\textheight
   \fancyhf{}\fancyfoot{}
- \begin{textblock}{0.05}(0.925,0.5)
+ \begin{textblock}{0.05}(0.9,0.5)
  {\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
-  \begin{textblock}{1}(0.1,0.0909)
+  \begin{textblock}{0.05}(0.062,0.0909){\rotatebox{90}{\rule{9in}{0.25pt}}}
   \end{textblock}
-  \begin{textblock}{1}(0.9,0.0909)
+  \begin{textblock}{0.05}(0.875,0.0909){\rotatebox{90}{\rule{9in}{0.25pt}}}
   \end{textblock}
 \fi}
 

--- a/inst/csas-style/tech-report-french.sty
+++ b/inst/csas-style/tech-report-french.sty
@@ -83,21 +83,17 @@
 %% Creates a header and footer on the long page sides on landscape pages
 \AddEverypageHook{\ifdim\textwidth=\textheight
   \fancyhf{}\fancyfoot{}
-\begin{textblock}{0.05}(0.925,0.5)
-{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
- \begin{textblock}{1}(0.1,0.0909)
-{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
-  \begin{textblock}{1}(0.9,0.0909)
-  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\begin{textblock}{0.05}(0.9,0.5)
+{\rotatebox{90}{\sffamily\selectfont\normalsize\thepage}}\end{textblock}
 \fi}
 
 %% For landscape pages in CSAS documents
 \usepackage{pdflscape} % rotates landscape pages
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
-  {-1in}
+  {8.5in}
 \setlength{\TPVertModule}
-  {-1in}
+  {11in}
 %% ------------------------------------------------------------------------------
 
 % Hyper links

--- a/inst/csas-style/tech-report.sty
+++ b/inst/csas-style/tech-report.sty
@@ -81,21 +81,17 @@
 %% Creates a header and footer on the long page sides on landscape pages
 \AddEverypageHook{\ifdim\textwidth=\textheight
   \fancyhf{}\fancyfoot{}
-\begin{textblock}{0.05}(0.925,0.5)
-{\rotatebox{90}{\sffamily\selectfont\small\thepage}}\end{textblock}
- \begin{textblock}{1}(0.1,0.0909)
-{\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
-  \begin{textblock}{1}(0.9,0.0909)
-  {\rotatebox{90}{\rule{9in}{0.25pt}}}\end{textblock}
+\begin{textblock}{0.05}(0.9,0.5)
+{\rotatebox{90}{\sffamily\selectfont\normalsize\thepage}}\end{textblock}
 \fi}
 
 %% For landscape pages in CSAS documents
 \usepackage{pdflscape} % rotates landscape pages
 \usepackage[absolute]{textpos}
 \setlength{\TPHorizModule}
-  {-1in}
+  {8.5in}
 \setlength{\TPVertModule}
-  {-1in}
+  {11in}
 %% ------------------------------------------------------------------------------
 
 % Hyper links


### PR DESCRIPTION
I noticed that horizontal lines were no longer in the header and footer of landscape pages for resdocs. If this was not intentional, this is code to add horizontal lines and adjusted spacing of headers/footers on landscape pages to match portrait pages