### PR TITLE
added open licence statement to res doc style files

### DIFF
--- a/inst/csas-style/res-doc-french.sty
+++ b/inst/csas-style/res-doc-french.sty
@@ -660,6 +660,12 @@ Ottawa ON K1A 0E6\\
 
 \vspace{-1mm}
 \textcopyright\ Sa Majest\'{e} la Roi du chef du Canada, repr\'{e}sent\'{e} par le ministre\\ du minist\`{e}re des P\^{e}ches et des Oc\'{e}ans, \rdYear{}\\
+
+\vspace{1.9mm}
+Ce rapport est publi\'{e} sous la \link{https://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada}{Licence du gouvernement ouvert -- Canada}\\
+\vspace{1.9mm}
+
+
 ISSN 2292-4272\\
 ISBN~\rdISBN{} \hspace{5mm} N$^{\circ}$ cat.~\rdCatNo
 \end{center}

--- a/inst/csas-style/res-doc.sty
+++ b/inst/csas-style/res-doc.sty
@@ -660,6 +660,14 @@ Ottawa ON K1A 0E6\\
 
 \vspace{-1mm}
 \textcopyright\ His Majesty the King in Right of Canada, as represented by the Minister of the\\ Department of Fisheries and Oceans, \rdYear{}\\
+
+\vspace{1.9mm}
+This report is published under the \link{https://open.canada.ca/en/open-government-licence-canada}{Open Government Licence -- Canada}\\
+\vspace{1.9mm}
+
+
+
+
 ISSN 1919-5044\\
 ISBN~\rdISBN{} \hspace{5mm} Cat.~No.~\rdCatNo
 \end{center}


### PR DESCRIPTION
This commit partly addresses [this issue](https://github.com/pbs-assess/csasdown/issues/273).

To fully address, the corresponding updated word templates also have to be included in the package, and if the same open licence statement is needed for tech reports, SARs, FSARs, etc, then those style files also need to be revised.