### PR TITLE
add report DOI to colophon and citation

### DIFF
--- a/inst/csas-style/tech-report-french.sty
+++ b/inst/csas-style/tech-report-french.sty
@@ -257,6 +257,7 @@
 \newcommand{\trCitation}{
 \begin{hangparas}{1em}{1}
 \trAuthsBack{} \trYear{}. \trTitle{}. Rapp. tech. can. sci. halieut. aquat. \trReportNum{}: \pageref{TRlastRoman}{}\,+\,\pageref{LastPage}{}\,p.
+\link{https://doi.org/\trDOI{}}{https://doi.org/\trDOI{}}
 \end{hangparas}}
 
 %%%%% Frontmatter %%%%%
@@ -377,8 +378,9 @@ par
 % Fourth page: Colophon
 \vspace*{\fill}
 \begin{center}
-\copyright{} Sa Majest\'{e} la Roi du chef du Canada, repr\'{e}sent\'{e} par le ministre\\ du minist\`{e}re des P\^{e}ches et des Oc\'{e}ans, \trYear{}\\
-N° de cat. Fs97-6/\trReportNum{}F-PDF \quad ISBN \trISBN{} \quad ISSN 1488-545X
+\copyright{} Sa Majest\'{e} la Roi du chef du Canada, repr\'{e}sent\'{e} par le ministre du minist\`{e}re des\\ P\^{e}ches et des Oc\'{e}ans, \trYear{}\\
+N° de cat. Fs97-6/\trReportNum{}F-PDF \quad ISBN \trISBN{} \quad ISSN 1488-545X\\
+\href{https://doi.org/\trDOI{}}{\textcolor{black}{\normalfont https://doi.org/\trDOI{}}}
 \end{center}
 \par
 \bigskip

--- a/inst/csas-style/tech-report.sty
+++ b/inst/csas-style/tech-report.sty
@@ -257,6 +257,7 @@
 \newcommand{\trCitation}{
 \begin{hangparas}{1em}{1}
 \trAuthsBack{} \trYear{}. \trTitle{}. Can. Tech. Rep. Fish. Aquat. Sci. \trReportNum{}: \pageref{TRlastRoman}{}\,+\,\pageref{LastPage}{}\,p.
+\link{https://doi.org/\trDOI{}}{https://doi.org/\trDOI{}}
 \end{hangparas}}
 
 %%%%% Frontmatter %%%%%
@@ -377,8 +378,9 @@ by
 % Fourth page: Colophon
 \vspace*{\fill}
 \begin{center}
-\copyright{} His Majesty the King in Right of Canada, as represented by the Minister of the\\ Department of Fisheries and Oceans, \trYear{}\\
-Cat. No. Fs97-6/\trReportNum{}E-PDF \quad ISBN \trISBN{} \quad ISSN 1488-5379
+\copyright{} His Majesty the King in Right of Canada, as represented by the Minister \\of the Department of Fisheries and Oceans, \trYear{}\\
+Cat. No. Fs97-6/\trReportNum{}E-PDF \quad ISBN \trISBN{} \quad ISSN 1488-5379\\
+\href{https://doi.org/\trDOI{}}{\textcolor{black}{\normalfont https://doi.org/\trDOI{}}}
 \end{center}
 \par
 \bigskip

--- a/inst/csas-tex/tech-report-french.tex
+++ b/inst/csas-tex/tech-report-french.tex
@@ -69,6 +69,7 @@ $header-includes$
 \newcommand{\trTitle}{$title$}
 \newcommand{\trYear}{$year$}
 \newcommand{\trReportNum}{$report_number$}
+\newcommand{\trDOI}{$report_DOI$}
 % Optional
 \newcommand{\trAuthFootA}{$author_footnote$}
 \newcommand{\trAuthsLong}{$author$}

--- a/inst/csas-tex/tech-report.tex
+++ b/inst/csas-tex/tech-report.tex
@@ -69,6 +69,7 @@ $header-includes$
 \newcommand{\trTitle}{$title$}
 \newcommand{\trYear}{$year$}
 \newcommand{\trReportNum}{$report_number$}
+\newcommand{\trDOI}{$report_DOI$}
 % Optional
 \newcommand{\trAuthFootA}{$author_footnote$}
 \newcommand{\trAuthsLong}{$author$}

--- a/inst/rmarkdown/templates/techreport/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/techreport/skeleton/skeleton.Rmd
@@ -11,6 +11,7 @@ author_list: "Last, F.M. and Smith, A.B."
 region: Pacific Region
 french_region: Région du Pacifique
 isbn: ""
+report_DOI: "##.####/xxxxx" # do not include https://doi.org/
 address: |
   ^1^Pacific Biological Station\
      Fisheries and Oceans Canada, 3190 Hammond Bay Road\


### PR DESCRIPTION
- omitting "https://doi.org/" from the index.Rmd simplifies formatting